### PR TITLE
Polishing tax plugin

### DIFF
--- a/src/assets/css/public.css
+++ b/src/assets/css/public.css
@@ -1,3 +1,3 @@
-.better-tax-hidden {
+.wc-euvat-hidden {
 	display: none;
 }

--- a/src/assets/js/admin.js
+++ b/src/assets/js/admin.js
@@ -27,10 +27,6 @@
 			nonce: wc_euvat_l10n.nonce
 		};
 
-		if (req_type == 'distance_taxes') {
-			req_data.countries = $( 'select[name="wc_vat_distance_selling_countries[]"]' ).val();
-		}
-
 		$.ajax(
 			{
 				type: 'POST',
@@ -198,21 +194,12 @@
 		}
 	);
 
-	// Import taxes for Digital Goods & Distance Selling
+	// Import taxes for Digital Goods
 	$( '.import-digital-tax-rates' ).on(
 		'click',
 		function(e) {
 			e.preventDefault();
 			euVatAjax( 'digital_taxes', $( this ) );
-		}
-	);
-
-	// Distance selling
-	$( '.import-distance-tax-rates' ).on(
-		'click',
-		function(e) {
-			e.preventDefault();
-			euVatAjax( 'distance_taxes', $( this ) );
 		}
 	);
 })( jQuery );

--- a/src/classes/admin.php
+++ b/src/classes/admin.php
@@ -23,7 +23,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * Class constructor.
 		 */
 		public function __construct() {
-			add_action( 'init', array( &$this, 'init' ) );
+			add_action( 'init', array( $this, 'init' ) );
 		}
 
 		/**
@@ -31,13 +31,13 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 */
 		public function init() {
 			if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-				add_filter( 'woocommerce_get_settings_tax', array( &$this, 'settings' ), PHP_INT_MAX, 2 );
+				add_filter( 'woocommerce_get_settings_tax', array( $this, 'settings' ), PHP_INT_MAX, 2 );
 				add_action( 'admin_enqueue_scripts', array( $this, 'scripts' ) );
-				add_action( 'woocommerce_admin_field_button', array( &$this, 'button_field' ) );
-				add_action( 'wp_ajax_add_digital_taxes', array( &$this, 'ajax_digital_tax_rates' ) );
-				add_action( 'wp_ajax_add_distance_taxes', array( &$this, 'ajax_distance_tax_rates' ) );
-				add_action( 'wp_ajax_add_tax_id_check', array( &$this, 'ajax_tax_id_check' ) );
-				add_action( 'woocommerce_admin_order_data_after_billing_address', array( &$this, 'order_meta' ) );
+				add_action( 'woocommerce_admin_field_button', array( $this, 'button_field' ) );
+				add_action( 'wp_ajax_add_digital_taxes', array( $this, 'ajax_digital_tax_rates' ) );
+				add_action( 'wp_ajax_add_distance_taxes', array( $this, 'ajax_distance_tax_rates' ) );
+				add_action( 'wp_ajax_add_tax_id_check', array( $this, 'ajax_tax_id_check' ) );
+				add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'order_meta' ) );
 			}
 		}
 

--- a/src/classes/admin.php
+++ b/src/classes/admin.php
@@ -35,7 +35,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 				add_action( 'admin_enqueue_scripts', array( $this, 'scripts' ) );
 				add_action( 'woocommerce_admin_field_button', array( $this, 'button_field' ) );
 				add_action( 'wp_ajax_add_digital_taxes', array( $this, 'ajax_digital_tax_rates' ) );
-				add_action( 'wp_ajax_add_distance_taxes', array( $this, 'ajax_distance_tax_rates' ) );
 				add_action( 'wp_ajax_add_tax_id_check', array( $this, 'ajax_tax_id_check' ) );
 				add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'order_meta' ) );
 			}
@@ -151,35 +150,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 					'type' => 'sectionend',
 					'id'   => 'wc_euvat_digital_goods',
 				),
-				array(
-					'id'    => 'wc_euvat_distance_selling',
-					'title' => esc_html__( 'EU Tax Handling - Distance Selling (B2C)', 'eu-vat-b2b-taxes' ),
-					'type'  => 'title',
-					'desc'  => sprintf( esc_html__( 'You need to register for EU Tax ID in countries where you reach %1$sDistance Selling EU Tax thresholds%2$s. Add countries where you are registered and the customers will be charged the local VAT. Applies only to products sold to consumers (B2C).', 'eu-vat-b2b-taxes' ), '<a href="https://www.vatlive.com/eu-vat-rules/distance-selling/distance-selling-eu-vat-thresholds/" target="_blank">', '</a>' ),
-				),
-				array(
-					'id'      => 'wc_vat_distance_selling_enable',
-					'title'   => esc_html__( 'EU VAT Handling for Distance Selling', 'eu-vat-b2b-taxes' ),
-					'type'    => 'checkbox',
-					'desc'    => esc_html__( 'Enable', 'eu-vat-b2b-taxes' ),
-					'default' => 'no',
-				),
-				array(
-					'id'    => 'wc_vat_distance_selling_countries',
-					'title' => esc_html__( 'Select countries for which you would like to import tax rates.', 'eu-vat-b2b-taxes' ),
-					'type'  => 'multi_select_countries',
-				),
-				array(
-					'id'      => 'wc_vat_distance_selling_rates',
-					'title'   => esc_html__( 'Import tax rates for specific EU countries', 'eu-vat-b2b-taxes' ),
-					'type'    => 'button',
-					'default' => esc_html__( 'Import Taxes', 'eu-vat-b2b-taxes' ),
-					'class'   => 'button-secondary import-distance-tax-rates',
-				),
-				array(
-					'type' => 'sectionend',
-					'id'   => 'wc_euvat_distance_selling',
-				),
 			);
 
 			return array_merge( $settings, $tax_options );
@@ -239,23 +209,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 		}
 
 		/**
-		 * AJAX request for importing distance selling tax rates.
-		 */
-		public function ajax_distance_tax_rates() {
-			// CSRF protection
-			check_ajax_referer( '__wc_euvat_nonce', 'nonce' );
-
-			$tax_name = esc_html__( 'Distance Selling', 'eu-vat-b2b-taxes' );
-			$tax_slug = 'distance-selling';
-
-			// Add taxes to DB
-			$response = $this->add_taxes_to_db( $tax_name, $tax_slug );
-
-			// Return response to JS
-			wp_send_json( $response );
-		}
-
-		/**
 		 * Add tax rates to DB.
 		 *
 		 * @param string $name Name used to define tax rates
@@ -287,16 +240,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 				);
 			}
 
-			// Specific settings for `distance-selling`
-			if ( 'distance-selling' === $slug ) {
-				$countries = $this->get_countries();
-				$countries = json_decode( json_encode( $countries ), true );
-
-				// Update countries cause we refresh the page after AJAX call
-				// And, we don't want to lose the option set for importing taxes for the specific countries
-				update_option( 'wc_vat_distance_selling_countries', $countries );
-			}
-
 			// Fetch tax rates
 			$rates = $this->rates();
 			$data  = $rates->get_tax_rates();
@@ -313,12 +256,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 				$i = 0;
 
 				foreach ( $data as $key => $value ) {
-					if ( 'distance-selling' === $slug && $countries ) {
-						if ( ! in_array( $key, $countries ) ) {
-							continue;
-						}
-					}
-
 					$query  = $wpdb->prepare(
 						"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_country = %s AND tax_rate_class = %s",
 						$key,

--- a/src/classes/admin.php
+++ b/src/classes/admin.php
@@ -407,23 +407,16 @@ namespace Niteo\WooCart\EUVatTaxes {
 		}
 
 		/**
-		 * Returns POST data for multi-select countries.
-		 */
-		public function get_countries() {
-			return array_map( 'sanitize_text_field', $_POST['countries'] );
-		}
-
-		/**
 		 * Initiate the Vies class for Tax ID check.
 		 */
-		public function vies() {
+		public function vies() : Vies {
 			return new Vies();
 		}
 
 		/**
 		 * Initiate the Rates class to fetch tax rates.
 		 */
-		public function rates() {
+		public function rates() : Rates {
 			return new Rates();
 		}
 

--- a/src/classes/config.php
+++ b/src/classes/config.php
@@ -58,7 +58,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		/**
 		 * @var array
 		 */
-		private $notices = array();
+		public $notices = array();
 
 		/**
 		 * Class constructor.
@@ -82,9 +82,9 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * Checks the environment on loading WordPress, just in case the environment changes after activation.
 		 */
 		public function check_environment() {
-			if ( ! $this->is_environment_compatible() && is_plugin_active( self::PLUGIN_BASE ) ) {
+			if ( ! $this->is_environment_compatible() && is_plugin_active( $this->get_plugin_base() ) ) {
 				$this->deactivate_plugin();
-				$this->add_admin_notice( 'bad_environment', 'error', self::PLUGIN_NAME . ' has been deactivated. ' . $this->get_environment_message() );
+				$this->add_admin_notice( 'bad_environment', 'error', $this->get_plugin_name() . ' has been deactivated. ' . $this->get_environment_message() );
 			}
 		}
 
@@ -99,8 +99,8 @@ namespace Niteo\WooCart\EUVatTaxes {
 					'error',
 					sprintf(
 						'%s requires WordPress version %s or higher. Please %supdate WordPress &raquo;%s',
-						'<strong>' . self::PLUGIN_NAME . '</strong>',
-						self::MINIMUM_WP_VERSION,
+						'<strong>' . $this->get_plugin_name() . '</strong>',
+						$this->get_wp_version(),
 						'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
 						'</a>'
 					)
@@ -114,11 +114,11 @@ namespace Niteo\WooCart\EUVatTaxes {
 					'error',
 					sprintf(
 						'%1$s requires WooCommerce version %2$s or higher. Please %3$supdate WooCommerce%4$s to the latest version, or %5$sdownload the minimum required version &raquo;%6$s',
-						'<strong>' . self::PLUGIN_NAME . '</strong>',
-						self::MINIMUM_WC_VERSION,
+						'<strong>' . $this->get_plugin_name() . '</strong>',
+						$this->get_wc_version(),
 						'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
 						'</a>',
-						'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . self::MINIMUM_WC_VERSION . '.zip' ) . '">',
+						'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . $this->get_wc_version() . '.zip' ) . '">',
 						'</a>'
 					)
 				);
@@ -130,13 +130,9 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 */
 		public function admin_notices() {
 			foreach ( (array) $this->notices as $notice_key => $notice ) {
-				?>
-
-				<div class="<?php echo esc_attr( $notice['class'] ); ?>">
-					<p><?php echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) ); ?></p>
-				</div>
-
-				<?php
+				echo '<div class="' . esc_attr( $notice['class'] ) . '">';
+				echo '<p>' . wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) ) . '</p>';
+				echo '</div>';
 			}
 		}
 
@@ -160,7 +156,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * @return bool
 		 */
 		public function is_environment_compatible() {
-			return version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '>=' );
+			return version_compare( PHP_VERSION, $this->get_php_version(), '>=' );
 		}
 
 		/**
@@ -171,7 +167,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		public function get_environment_message() {
 			return sprintf(
 				esc_html__( 'The minimum PHP version required for this plugin is %1$s. You are running %2$s.', 'eu-vat-b2b-taxes' ),
-				self::MINIMUM_PHP_VERSION,
+				$this->get_php_version(),
 				PHP_VERSION
 			);
 		}
@@ -190,12 +186,12 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 *
 		 * @return bool
 		 */
-		private function is_wp_compatible() {
-			if ( ! self::MINIMUM_WP_VERSION ) {
+		public function is_wp_compatible() {
+			if ( ! $this->get_wp_version() ) {
 				return true;
 			}
 
-			return version_compare( get_bloginfo( 'version' ), self::MINIMUM_WP_VERSION, '>=' );
+			return version_compare( get_bloginfo( 'version' ), $this->get_wp_version(), '>=' );
 		}
 
 		/**
@@ -203,23 +199,58 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 *
 		 * @return bool
 		 */
-		private function is_wc_compatible() {
-			if ( ! self::MINIMUM_WC_VERSION ) {
+		public function is_wc_compatible() {
+			if ( ! $this->get_wc_version() ) {
 				return true;
 			}
 
-			return defined( 'WC_VERSION' ) && version_compare( WC_VERSION, self::MINIMUM_WC_VERSION, '>=' );
+			return defined( 'WC_VERSION' ) && version_compare( WC_VERSION, $this->get_wc_version(), '>=' );
 		}
 
 		/**
 		 * Deactivates the plugin.
 		 */
 		protected function deactivate_plugin() {
-			deactivate_plugins( self::PLUGIN_BASE );
+			deactivate_plugins( $this->get_plugin_base() );
 
 			if ( isset( $_GET['activate'] ) ) {
 				unset( $_GET['activate'] );
 			}
+		}
+
+		/**
+		 * Returns PLUGIN_NAME.
+		 */
+		public function get_plugin_name() {
+			return self::PLUGIN_NAME;
+		}
+
+		/**
+		 * Returns PLUGIN_BASE.
+		 */
+		public function get_plugin_base() {
+			return self::PLUGIN_BASE;
+		}
+
+		/**
+		 * Returns MINIMUM_PHP_VERSION.
+		 */
+		public function get_php_version() {
+			return self::MINIMUM_PHP_VERSION;
+		}
+
+		/**
+		 * Returns MINIMUM_WP_VERSION.
+		 */
+		public function get_wp_version() {
+			return self::MINIMUM_WP_VERSION;
+		}
+
+		/**
+		 * Returns MINIMUM_WC_VERSION.
+		 */
+		public function get_wc_version() {
+			return self::MINIMUM_WC_VERSION;
 		}
 
 	}

--- a/src/classes/config.php
+++ b/src/classes/config.php
@@ -18,7 +18,32 @@ namespace Niteo\WooCart\EUVatTaxes {
 		/**
 		 * @var string
 		 */
+		public const PLUGIN_NAME = 'EU VAT & B2B Taxes';
+
+		/**
+		 * @var string
+		 */
+		public const PLUGIN_BASE = 'eu-vat-b2b-taxes/eu-vat-b2b-taxes.php';
+
+		/**
+		 * @var string
+		 */
 		public const VERSION = '@##VERSION##@';
+
+		/**
+		 * @var string
+		 */
+		public const MINIMUM_PHP_VERSION = '5.6';
+
+		/**
+		 * @var string
+		 */
+		public const MINIMUM_WP_VERSION = '4.8.12';
+
+		/**
+		 * @var string
+		 */
+		public const MINIMUM_WC_VERSION = '4.2.0';
 
 		/**
 		 * @var string
@@ -31,9 +56,17 @@ namespace Niteo\WooCart\EUVatTaxes {
 		public static $plugin_path;
 
 		/**
+		 * @var array
+		 */
+		private $notices = array();
+
+		/**
 		 * Class constructor.
 		 */
 		public function __construct() {
+			add_action( 'admin_init', array( $this, 'check_environment' ) );
+			add_action( 'admin_init', array( $this, 'add_plugin_notices' ) );
+			add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
 			add_action( 'init', array( $this, 'init' ) );
 		}
 
@@ -43,6 +76,150 @@ namespace Niteo\WooCart\EUVatTaxes {
 		public function init() {
 			self::$plugin_url  = plugin_dir_url( dirname( __FILE__ ) );
 			self::$plugin_path = plugin_dir_path( dirname( __FILE__ ) );
+		}
+
+		/**
+		 * Checks the environment on loading WordPress, just in case the environment changes after activation.
+		 */
+		public function check_environment() {
+			if ( ! $this->is_environment_compatible() && is_plugin_active( self::PLUGIN_BASE ) ) {
+				$this->deactivate_plugin();
+				$this->add_admin_notice( 'bad_environment', 'error', self::PLUGIN_NAME . ' has been deactivated. ' . $this->get_environment_message() );
+			}
+		}
+
+		/**
+		 * Adds notices for out-of-date WordPress and/or WooCommerce versions.
+		 */
+		public function add_plugin_notices() {
+			// Check for WP version
+			if ( ! $this->is_wp_compatible() ) {
+				$this->add_admin_notice(
+					'update_wordpress',
+					'error',
+					sprintf(
+						'%s requires WordPress version %s or higher. Please %supdate WordPress &raquo;%s',
+						'<strong>' . self::PLUGIN_NAME . '</strong>',
+						self::MINIMUM_WP_VERSION,
+						'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
+						'</a>'
+					)
+				);
+			}
+
+			// Check for WooCommerce version
+			if ( ! $this->is_wc_compatible() ) {
+				$this->add_admin_notice(
+					'update_woocommerce',
+					'error',
+					sprintf(
+						'%1$s requires WooCommerce version %2$s or higher. Please %3$supdate WooCommerce%4$s to the latest version, or %5$sdownload the minimum required version &raquo;%6$s',
+						'<strong>' . self::PLUGIN_NAME . '</strong>',
+						self::MINIMUM_WC_VERSION,
+						'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
+						'</a>',
+						'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . self::MINIMUM_WC_VERSION . '.zip' ) . '">',
+						'</a>'
+					)
+				);
+			}
+		}
+
+		/**
+		 * Displays any admin notices added with add_admin_notice()
+		 */
+		public function admin_notices() {
+			foreach ( (array) $this->notices as $notice_key => $notice ) {
+				?>
+
+				<div class="<?php echo esc_attr( $notice['class'] ); ?>">
+					<p><?php echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) ); ?></p>
+				</div>
+
+				<?php
+			}
+		}
+
+		/**
+		 * Adds an admin notice to be displayed.
+		 *
+		 * @param string $slug the slug for the notice
+		 * @param string $class the css class for the notice
+		 * @param string $message the notice message
+		 */
+		private function add_admin_notice( $slug, $class, $message ) {
+			$this->notices[ $slug ] = array(
+				'class'   => $class,
+				'message' => $message,
+			);
+		}
+
+		/**
+		 * Determines if the server environment is compatible with this plugin.
+		 *
+		 * @return bool
+		 */
+		public function is_environment_compatible() {
+			return version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '>=' );
+		}
+
+		/**
+		 * Gets the message for display when the environment is incompatible with this plugin.
+		 *
+		 * @return string
+		 */
+		public function get_environment_message() {
+			return sprintf(
+				esc_html__( 'The minimum PHP version required for this plugin is %1$s. You are running %2$s.', 'eu-vat-b2b-taxes' ),
+				self::MINIMUM_PHP_VERSION,
+				PHP_VERSION
+			);
+		}
+
+		/**
+		 * Determines if the plugin is compatible to run.
+		 *
+		 * @return bool
+		 */
+		public function is_plugin_compatible() {
+			return $this->is_wp_compatible() && $this->is_wc_compatible();
+		}
+
+		/**
+		 * Determines if the WordPress compatible.
+		 *
+		 * @return bool
+		 */
+		private function is_wp_compatible() {
+			if ( ! self::MINIMUM_WP_VERSION ) {
+				return true;
+			}
+
+			return version_compare( get_bloginfo( 'version' ), self::MINIMUM_WP_VERSION, '>=' );
+		}
+
+		/**
+		 * Determines if the WooCommerce compatible.
+		 *
+		 * @return bool
+		 */
+		private function is_wc_compatible() {
+			if ( ! self::MINIMUM_WC_VERSION ) {
+				return true;
+			}
+
+			return defined( 'WC_VERSION' ) && version_compare( WC_VERSION, self::MINIMUM_WC_VERSION, '>=' );
+		}
+
+		/**
+		 * Deactivates the plugin.
+		 */
+		protected function deactivate_plugin() {
+			deactivate_plugins( self::PLUGIN_BASE );
+
+			if ( isset( $_GET['activate'] ) ) {
+				unset( $_GET['activate'] );
+			}
 		}
 
 	}

--- a/src/classes/config.php
+++ b/src/classes/config.php
@@ -33,7 +33,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		/**
 		 * @var string
 		 */
-		public const MINIMUM_PHP_VERSION = '5.6';
+		public const MINIMUM_PHP_VERSION = '7.2';
 
 		/**
 		 * @var string

--- a/src/classes/config.php
+++ b/src/classes/config.php
@@ -208,17 +208,6 @@ namespace Niteo\WooCart\EUVatTaxes {
 		}
 
 		/**
-		 * Deactivates the plugin.
-		 */
-		protected function deactivate_plugin() {
-			deactivate_plugins( $this->get_plugin_base() );
-
-			if ( isset( $_GET['activate'] ) ) {
-				unset( $_GET['activate'] );
-			}
-		}
-
-		/**
 		 * Returns PLUGIN_NAME.
 		 */
 		public function get_plugin_name() {
@@ -251,6 +240,17 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 */
 		public function get_wc_version() {
 			return self::MINIMUM_WC_VERSION;
+		}
+
+		/**
+		 * Deactivates the plugin.
+		 */
+		protected function deactivate_plugin() {
+			deactivate_plugins( $this->get_plugin_base() );
+
+			if ( isset( $_GET['activate'] ) ) {
+				unset( $_GET['activate'] );
+			}
 		}
 
 	}

--- a/src/classes/rates.php
+++ b/src/classes/rates.php
@@ -88,7 +88,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 					}
 
 					// Add tax rates data to footer
-					add_action( 'admin_footer', array( &$this, 'footer' ) );
+					add_action( 'admin_footer', array( $this, 'footer' ) );
 				}
 			}
 		}

--- a/src/classes/reports.php
+++ b/src/classes/reports.php
@@ -24,7 +24,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * Class constructor.
 		 */
 		public function __construct() {
-			add_filter( 'woocommerce_admin_reports', array( &$this, 'tabs' ), 10, 1 );
+			add_filter( 'woocommerce_admin_reports', array( $this, 'tabs' ), 10, 1 );
 		}
 
 		/**

--- a/src/classes/userview.php
+++ b/src/classes/userview.php
@@ -18,27 +18,50 @@ namespace Niteo\WooCart\EUVatTaxes {
 	class UserView {
 
 		/**
+		 * @var string
+		 */
+		public $enable_digital_tax;
+
+		/**
+		 * @var string
+		 */
+		public $b2b_sales_status;
+
+		/**
+		 * @var string
+		 */
+		public $b2b_tax_id_required;
+
+		/**
 		 * Class constructor.
 		 */
 		public function __construct() {
-			add_action( 'init', array( &$this, 'init' ) );
+			add_action( 'init', array( $this, 'init' ) );
 		}
 
 		/**
 		 * Initialize the user facing part of the plugin.
 		 */
-		public function init() {
-			add_action( 'wp_enqueue_scripts', array( &$this, 'scripts' ) );
-			add_filter( 'woocommerce_billing_fields', array( &$this, 'checkout_fields' ) );
-			add_action( 'woocommerce_checkout_update_order_review', array( &$this, 'calculate_tax' ) );
-			add_action( 'woocommerce_after_checkout_validation', array( &$this, 'checkout_validation' ), PHP_INT_MAX, 2 );
-			add_action( 'woocommerce_checkout_update_order_meta', array( &$this, 'update_order_meta' ), 10, 1 );
+		public function init() : void {
+			// Get user settings for the plugin
+			$this->enable_digital_tax = sanitize_text_field( get_option( 'wc_vat_digital_goods_enable', 'no' ) );
+			$this->b2b_sales_status = sanitize_text_field( get_option( 'wc_b2b_sales', 'none' ) );
+			$this->b2b_tax_id_required = sanitize_text_field( get_option( 'wc_tax_id_required', 'no' ) );
+
+			// Assign Hooks & Filters
+			add_filter( 'woocommerce_billing_fields', array( $this, 'checkout_fields' ) );
+			add_filter( 'woocommerce_product_get_tax_class', array( $this, 'digital_goods' ), PHP_INT_MAX, 2 );
+			add_filter( 'woocommerce_product_get_tax_status', array( $this, 'digital_goods_verify' ), PHP_INT_MAX, 2 );
+
+			add_action( 'wp_enqueue_scripts', array( $this, 'scripts' ) );
+			add_action( 'woocommerce_after_checkout_validation', array( $this, 'checkout_validation' ), PHP_INT_MAX, 2 );
+			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'update_order_meta' ) );
 		}
 
 		/**
 		 * Add styles and scripts for the frontend.
 		 */
-		public function scripts() {
+		public function scripts() : void {
 			wp_enqueue_script( 'euvat-public', Config::$plugin_url . 'assets/js/public.js', array( 'jquery' ), Config::VERSION, true );
 			wp_enqueue_style( 'euvat-public', Config::$plugin_url . 'assets/css/public.css', '', Config::VERSION );
 
@@ -53,137 +76,86 @@ namespace Niteo\WooCart\EUVatTaxes {
 
 		/**
 		 * Add custom fields to the checkout page.
+		 *
+		 * @param array $fields Checkout fields contained in an array
+		 * @return array
 		 */
-		public function checkout_fields( $fields ) {
-			$b2b_sales = esc_html( get_option( 'wc_b2b_sales' ) );
+		public function checkout_fields( array $fields ) : array {
+			$b2b_sales = sanitize_text_field( get_option( 'wc_b2b_sales', 'none' ) );
 
-			// Show conditionally :)
-			if ( 'none' !== $b2b_sales ) {
-				// Check for business status.
-				$fields['business_check'] = array(
-					'label'    => esc_html__( 'Are you making this purchase as a Business entity?', 'eu-vat-b2b-taxes' ),
-					'type'     => 'checkbox',
-					'required' => false,
-					'class'    => array( 'better-tax-business-check', 'update_totals_on_change' ),
-					'clear'    => true,
-					'priority' => 5,
-				);
-
-					// Ask for VAT ID.
-					$fields['business_tax_id'] = array(
-						'label'    => esc_html__( 'Business Tax ID', 'eu-vat-b2b-taxes' ),
-						'type'     => 'text',
-						'required' => false,
-						'class'    => array( 'form-row-wide', 'better-tax-vat-id', 'better-tax-hidden', 'address-field' ),
-						'priority' => 6,
-					);
+			if ( 'none' === $b2b_sales ) {
+				return $fields;
 			}
+
+			// Check for business status
+			$fields['business_check'] = array(
+				'label'    => esc_html__( 'Are you making this purchase as a Business entity?', 'eu-vat-b2b-taxes' ),
+				'type'     => 'checkbox',
+				'required' => false,
+				'class'    => array( 'wc-euvat-business-check', 'update_totals_on_change' ),
+				'clear'    => true,
+				'priority' => 5,
+			);
+
+			// Ask for VAT ID
+			$fields['business_tax_id'] = array(
+				'label'    => esc_html__( 'Business Tax ID', 'eu-vat-b2b-taxes' ),
+				'type'     => 'text',
+				'required' => false,
+				'class'    => array( 'form-row-wide', 'wc-euvat-hidden', 'update_totals_on_change' ),
+				'priority' => 6,
+			);
 
 			return $fields;
 		}
 
 		/**
-		 * We are returning empty taxes to simplify our tax computation.
+		 * Taxation for digital goods.
 		 *
-		 * @return array
+		 * @param string $tax_class Tax class assigned to the product
+		 * @param object $product Object containing product information
+		 *
+		 * @return string
 		 */
-		public function return_tax( $taxes, $price, $rates, $price_includes_tax = false, $deprecated = false ) {
-			return array();
+		public function digital_goods( string $tax_class, object $product ) : string {
+			if ( 'no' === $this->enable_digital_tax ) {
+				return $tax_class;
+			}
+
+			if ( ! $product->get_virtual() && ! $product->get_downloadable() ) {
+				return $tax_class;
+			}
+			
+			return 'digital-goods';
 		}
 
 		/**
-		 * Simplifying taxation for the user.
+		 * Verifies the existence of the `digital-goods` tax class.
+		 * If not present, removes tax from the products.
 		 *
-		 * @todo Live validation for the Tax ID
-		 * @codeCoverageIgnore
+		 * @param string $tax_status Tax status assigned to the product
+		 * @param object $product Object containing product information
+		 *
+		 * @return string
 		 */
-		public function calculate_tax( $data ) {
-			$new_data = array();
-
-			// Parse the string.
-			parse_str( $data, $new_data );
-
-			// Customer billing details.
-			$country = $new_data['billing_country'];
-
-			// Set vat_exempt to false
-			$this->set_vat_exempt( false );
-
-			// For B2B
-			if ( isset( $new_data['business_check'] ) && ! empty( $new_data['business_check'] ) ) {
-				// Grab tax settings.
-				$b2b_sales = esc_html( get_option( 'wc_b2b_sales' ) );
-
-				// We will continue only if B2B sales are not disabled.
-				if ( 'none' !== $b2b_sales ) {
-					$b2b_home_tax    = esc_html( get_option( 'wc_tax_home_country' ) );
-					$b2b_eu_tax_id   = esc_html( get_option( 'wc_tax_eu_with_vatid' ) );
-					$b2b_tax_outside = esc_html( get_option( 'wc_tax_charge_vat' ) );
-					$base_location   = wc_get_base_location()['country'];
-
-					/**
-					 * Playing around with various combinations and then calculating the tax (if required).
-					 */
-
-					// If the base country and the customer country is same, and also if the tax charge option is ticked off, then do nothing.
-					if ( ( $base_location === $country ) && 'no' === $b2b_home_tax ) {
-						add_filter( 'woocommerce_calc_tax', array( &$this, 'return_tax' ), PHP_INT_MAX, 5 );
-					}
-
-					// If the sale is not made in the base country, and the option to not charge tax is ticked.
-					if ( ( $base_location !== $country ) && 'yes' === $b2b_tax_outside ) {
-						add_filter( 'woocommerce_calc_tax', array( &$this, 'return_tax' ), PHP_INT_MAX, 5 );
-					}
-
-					// Check if `business_tax_id` is provided and the option to not charge tax is turned on. We will return empty taxes if the first statement is true.
-					if ( isset( $new_data['business_tax_id'] ) && ! empty( $new_data['business_tax_id'] ) ) {
-						if ( 'yes' === $b2b_eu_tax_id ) {
-							// Doing Tax ID check over here
-							// We are using Vies class for validating our request
-							$validator = new Vies();
-							$bool      = $validator->isValid( $new_data['business_tax_id'], true );
-
-							if ( $bool ) {
-								$this->set_vat_exempt( true );
-								return;
-							}
-						}
-					}
-				}
-			} else {
-				// For B2C (handling digital goods and distance selling)
-				// Get cart items.
-				$items = WC()->cart->get_cart();
-
-				// Loop through each item and calculate tax.
-				foreach ( $items as $item ) {
-					$tax_class = $item['data']->get_tax_class();
-
-					// For digital goods.
-					if ( 'digital-goods' === $tax_class ) {
-						if ( 'no' === get_option( 'wc_vat_digital_goods_enable' ) ) {
-							$item['data']->set_tax_class( null );
-						}
-					}
-
-					// For distance selling.
-					if ( 'distance-selling' === $tax_class ) {
-						if ( 'no' === get_option( 'wc_euvat_distance_selling' ) ) {
-							// Remove `distance-selling-rate` from the tax list.
-							$item['data']->set_tax_class( null );
-						} else {
-							// Fetch digital selling countries where the taxes will be levied by the shop.
-							$ds_countries = get_option( 'wc_vat_distance_selling_countries' );
-
-							// If the customer country is not in the list, then continue as we are not going to charge in that case.
-							if ( ! in_array( $country, $ds_countries ) ) {
-								// Remove taxes here as well as the country is not in the list.
-								$item['data']->set_tax_class( null );
-							}
-						}
-					}
-				}
+		public function digital_goods_verify( string $tax_status, object $product ) : string {
+			if ( 'no' === $this->enable_digital_tax ) {
+				return $tax_status;
 			}
+
+			if ( ! $product->get_virtual() && ! $product->get_downloadable() ) {
+				return $tax_status;
+			}
+
+			// Fetch list of available tax classes
+			$tax_rates = $this->get_digital_tax_rate_for_user();
+
+			// In case of missing tax rates for user's country set to no-tax
+			if ( ! $tax_rates ) {
+				return 'none';
+			}
+
+			return $tax_status;
 		}
 
 		/**
@@ -192,14 +164,20 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * @param  array    $data An array of posted data.
 		 * @param  WP_Error $errors
 		 */
-		public function checkout_validation( $data, $errors ) {
-			if ( isset( $_POST['business_check'] ) ) {
-				if ( ! isset( $_POST['business_tax_id'] ) || empty( $_POST['business_tax_id'] ) ) {
-					if ( 'yes' === get_option( 'wc_tax_id_required' ) ) {
-						$errors->add( 'billing', sprintf( esc_html__( '%1$sBusiness Tax ID%2$s is a required field.', 'eu-vat-b2b-taxes' ), '<strong>', '</strong>' ) );
-					}
-				}
+		public function checkout_validation( array $data, \WP_Error $errors ) : void {
+			if ( 'no' === $this->b2b_tax_id_required ) {
+				return;
 			}
+
+			if ( ! isset( $_POST['business_check'] ) ) {
+				return;
+			}
+			
+			if ( ! empty( $_POST['business_tax_id'] ) ) {
+				return;
+			}
+
+			$errors->add( 'billing', sprintf( esc_html__( '%1$sBusiness Tax ID%2$s is a required field.', 'eu-vat-b2b-taxes' ), '<strong>', '</strong>' ) );
 		}
 
 		/**
@@ -208,14 +186,17 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * @param int $order_id Order ID
 		 * @return void
 		 */
-		public function update_order_meta( $order_id ) {
+		public function update_order_meta( int $order_id ) : void {
+			if ( ! isset( $_POST['business_check'] ) ) {
+				return;
+			}
+
 			$business_check = sanitize_text_field( $_POST['business_check'] );
+			$business_tax_id = sanitize_text_field( $_POST['business_tax_id'] );
 
 			if ( ! empty( $business_check ) ) {
 				update_post_meta( $order_id, 'b2b_sale', $business_check );
 			}
-
-			$business_tax_id = sanitize_text_field( $_POST['business_tax_id'] );
 
 			if ( ! empty( $business_tax_id ) ) {
 				update_post_meta( $order_id, 'business_tax_id', $business_tax_id );
@@ -223,12 +204,12 @@ namespace Niteo\WooCart\EUVatTaxes {
 		}
 
 		/**
-		 * Sets VAT exempt for the customer (only for B2B transactions).
+		 * Return tax rate for user's country for `digital-goods` tax class.
 		 *
-		 * @param bool $status Whether to enable or disable VAT exempt
+		 * @return array
 		 */
-		public function set_vat_exempt( $status ) {
-			return WC()->customer->set_is_vat_exempt( $status );
+		private function get_digital_tax_rate_for_user() : array {
+			return \WC_Tax::get_rates( 'digital-goods' );
 		}
 
 	}

--- a/src/classes/userview.php
+++ b/src/classes/userview.php
@@ -376,9 +376,8 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * Return tax rate for user's country for `digital-goods` tax class.
 		 *
 		 * @return array
-		 * @codeCoverageIgnore
 		 */
-		protected function get_digital_tax_rate_for_user() : array {
+		public function get_digital_tax_rate_for_user() : array {
 			return \WC_Tax::get_rates( 'digital-goods' );
 		}
 

--- a/src/classes/userview.php
+++ b/src/classes/userview.php
@@ -259,7 +259,7 @@ namespace Niteo\WooCart\EUVatTaxes {
 			}
 
 			// All conditions seem to be fine, so we need to check for VAT validation
-			$validator = new Vies();
+			$validator = $this->vies();
 			$is_valid  = $validator->isValid( $fields['business_tax_id'], true );
 
 			// If we are able to verify the ID, remove taxes
@@ -331,11 +331,11 @@ namespace Niteo\WooCart\EUVatTaxes {
 				return;
 			}
 
-			if ( ! isset( $_POST['business_check'] ) ) {
+			if ( ! isset( $data['business_check'] ) ) {
 				return;
 			}
 
-			if ( ! empty( $_POST['business_tax_id'] ) ) {
+			if ( ! empty( $data['business_tax_id'] ) ) {
 				return;
 			}
 
@@ -366,11 +366,19 @@ namespace Niteo\WooCart\EUVatTaxes {
 		}
 
 		/**
+		 * Initiate the Vies class for Tax ID check.
+		 */
+		public function vies() : Vies {
+			return new Vies();
+		}
+
+		/**
 		 * Return tax rate for user's country for `digital-goods` tax class.
 		 *
 		 * @return array
+		 * @codeCoverageIgnore
 		 */
-		private function get_digital_tax_rate_for_user() : array {
+		protected function get_digital_tax_rate_for_user() : array {
 			return \WC_Tax::get_rates( 'digital-goods' );
 		}
 

--- a/src/eu-vat-b2b-taxes.php
+++ b/src/eu-vat-b2b-taxes.php
@@ -34,14 +34,11 @@ namespace Niteo\WooCart\EUVatTaxes {
 			// Run on plugin activation
 			register_activation_hook( __FILE__, array( $config, 'activation_check' ) );
 
-			// Check for compatible environment
-			if ( $config->is_environment_compatible() && $config->is_plugin_compatible() ) {
-				// Load rest of the modules
-				new Admin();
-				new Rates();
-				new UserView();
-				new Reports();
-			}
+			// Load rest of the modules
+			new Admin();
+			new Rates();
+			new UserView();
+			new Reports();
 		}
 
 	}

--- a/src/eu-vat-b2b-taxes.php
+++ b/src/eu-vat-b2b-taxes.php
@@ -28,11 +28,20 @@ namespace Niteo\WooCart\EUVatTaxes {
 		 * Class constructor.
 		 */
 		public function __construct() {
-			new Config();
-			new Admin();
-			new Rates();
-			new UserView();
-			new Reports();
+			// Initialize plugin configuration
+			$config = new Config();
+
+			// Run on plugin activation
+			register_activation_hook( __FILE__, array( $config, 'activation_check' ) );
+
+			// Check for compatible environment
+			if ( $config->is_environment_compatible() && $config->is_plugin_compatible() ) {
+				// Load rest of the modules
+				new Admin();
+				new Rates();
+				new UserView();
+				new Reports();
+			}
 		}
 
 	}

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -53,7 +53,6 @@ class AdminTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'admin_enqueue_scripts', array( $admin, 'scripts' ) );
 		\WP_Mock::expectActionAdded( 'woocommerce_admin_field_button', array( $admin, 'button_field' ) );
 		\WP_Mock::expectActionAdded( 'wp_ajax_add_digital_taxes', array( $admin, 'ajax_digital_tax_rates' ) );
-		\WP_Mock::expectActionAdded( 'wp_ajax_add_distance_taxes', array( $admin, 'ajax_distance_tax_rates' ) );
 		\WP_Mock::expectActionAdded( 'wp_ajax_add_tax_id_check', array( $admin, 'ajax_tax_id_check' ) );
 		\WP_Mock::expectActionAdded( 'woocommerce_admin_order_data_after_billing_address', array( $admin, 'order_meta' ) );
 
@@ -320,7 +319,6 @@ class AdminTest extends TestCase {
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::add_taxes_to_db
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::get_countries
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::rates
 	 * @covers \Niteo\WooCart\EUVatTaxes\Rates::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\Rates::get_tax_rates
@@ -368,102 +366,13 @@ class AdminTest extends TestCase {
 						)
 					);
 		$mock->shouldReceive( 'rates' )->andReturn( $rates );
-		$mock->shouldReceive( 'get_countries' )->andReturn( array( 'DE', 'SI' ) );
 
 		$this->assertEquals(
 			array(
 				'status'  => 'success',
 				'message' => '2 tax entries have been updated',
 			),
-			$mock->add_taxes_to_db( 'Distance Selling', 'distance-selling' )
-		);
-	}
-
-	/**
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::add_taxes_to_db
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::get_countries
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::rates
-	 * @covers \Niteo\WooCart\EUVatTaxes\Rates::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\Rates::get_tax_rates
-	 * @covers \Niteo\WooCart\EUVatTaxes\Rates::fetch_tax_rates
-	 */
-	public function testAddTaxesToDbDistanceNoCountries() {
-		global $wpdb;
-
-		$wpdb = new class() {
-			public $prefix = 'wp_';
-
-			function prepare() {
-				return true;
-			}
-			function get_row() {
-				return false;
-			}
-			function update() {
-				return true;
-			}
-			function insert() {
-				return true;
-			}
-		};
-
-		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Admin' )->makePartial();
-
-		\WP_Mock::userFunction(
-			'update_option',
-			array(
-				'return' => true,
-			)
-		);
-
-		$rates = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Rates' );
-		$rates->shouldReceive( 'get_tax_rates' )
-					->andReturn(
-						array(
-							'DE' => array(
-								'standard_rate' => '20.0',
-							),
-							'SI' => array(
-								'standard_rate' => '30.0',
-							),
-						)
-					);
-		$mock->shouldReceive( 'rates' )->andReturn( $rates );
-		$mock->shouldReceive( 'get_countries' )->andReturn( array( 'FR', 'BE' ) );
-
-		$this->assertEquals(
-			array(
-				'status'  => 'success',
-				'message' => '0 tax entries have been updated',
-			),
-			$mock->add_taxes_to_db( 'Distance Selling', 'distance-selling' )
-		);
-	}
-
-	/**
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::get_countries
-	 */
-	public function testGetCountries() {
-		$admin = new Admin();
-
-		$_POST['countries'] = array(
-			'DE',
-			'SI',
-		);
-
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'times'  => 2,
-				'return' => 'SANITIZED_VALUE',
-			)
-		);
-
-		$this->assertEquals(
-			array( 'SANITIZED_VALUE', 'SANITIZED_VALUE' ),
-			$admin->get_countries()
+			$mock->add_taxes_to_db( 'Digital Goods', 'digital-goods' )
 		);
 	}
 

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -140,33 +140,6 @@ class AdminTest extends TestCase {
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::ajax_distance_tax_rates
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::add_taxes_to_db
-	 */
-	public function testAjaxDistanceTaxRates() {
-		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Admin' )
-						->makePartial();
-		$mock->shouldReceive( 'add_taxes_to_db' )
-				 ->andReturn( true );
-
-		\WP_Mock::userFunction(
-			'check_ajax_referer',
-			array(
-				'return' => true,
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_send_json',
-			array(
-				'return' => true,
-			)
-		);
-
-		$mock->ajax_distance_tax_rates();
-	}
-
-	/**
-	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::order_meta
 	 * @covers \Niteo\WooCart\EUVatTaxes\Admin::add_html
 	 */

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -131,12 +131,12 @@ class ConfigTest extends TestCase {
 	 * @covers \Niteo\WooCart\EUVatTaxes\Config::admin_notices
 	 */
 	public function testAdminNotices() {
-		$config = new Config();
+		$config          = new Config();
 		$config->notices = array(
 			'notice1' => array(
 				'class'   => 'class1',
 				'message' => 'message1',
-			)
+			),
 		);
 
 		\WP_Mock::userFunction(

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -43,19 +43,169 @@ class ConfigTest extends TestCase {
 		$config = new Config();
 
 		\WP_Mock::userFunction(
-			'\plugin_dir_url',
+			'plugin_dir_url',
 			array(
 				'return' => true,
 			)
 		);
 		\WP_Mock::userFunction(
-			'\plugin_dir_path',
+			'plugin_dir_path',
 			array(
 				'return' => true,
 			)
 		);
 
 		$config->init();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::check_environment
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_environment_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::deactivate_plugin
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::add_admin_notice
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_environment_message
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_php_version
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_plugin_name
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_plugin_base
+	 */
+	public function testCheckEnvironment() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'is_environment_compatible' )->andReturn( false );
+
+		$_GET['activate'] = 'yes';
+
+		\WP_Mock::userFunction(
+			'is_plugin_active',
+			array(
+				'return' => true,
+			)
+		);
+		\WP_Mock::userFunction(
+			'deactivate_plugins',
+			array(
+				'return' => true,
+			)
+		);
+
+		$mock->check_environment();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::add_plugin_notices
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wp_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wc_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::add_admin_notice
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_plugin_name
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wc_version
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wp_version
+	 */
+	public function testAddPluginNotices() {
+		$config = new Config();
+
+		\WP_Mock::userFunction(
+			'get_bloginfo',
+			array(
+				'return' => '4.0',
+			)
+		);
+		\WP_Mock::userFunction(
+			'admin_url',
+			array(
+				'return' => true,
+			)
+		);
+		\WP_Mock::userFunction(
+			'esc_url',
+			array(
+				'return' => '#',
+			)
+		);
+
+		$config->add_plugin_notices();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::admin_notices
+	 */
+	public function testAdminNotices() {
+		$config = new Config();
+		$config->notices = array(
+			'notice1' => array(
+				'class'   => 'class1',
+				'message' => 'message1',
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_kses',
+			array(
+				'return' => 'message1',
+			)
+		);
+
+		$this->expectOutputString( '<div class="class1"><p>message1</p></div>' );
+		$config->admin_notices();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wc_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wc_version
+	 */
+	public function testIsWcCompatible() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'get_wc_version' )->andReturn( false );
+		$this->assertTrue( $mock->is_wc_compatible() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wp_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wp_version
+	 */
+	public function testIsWpCompatible() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'get_wp_version' )->andReturn( false );
+		$this->assertTrue( $mock->is_wp_compatible() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_plugin_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wp_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_wc_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wp_version
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_wc_version
+	 */
+	public function testIsPluginCompatible() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'is_wp_compatible', 'is_wc_compatible' )->andReturn( true );
+		$this->assertTrue( $mock->is_plugin_compatible() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_environment_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_php_version
+	 */
+	public function testEnvironmentCompatibleTrue() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'get_php_version' )->andReturn( '1.0' );
+		$this->assertTrue( $mock->is_environment_compatible() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::is_environment_compatible
+	 * @covers \Niteo\WooCart\EUVatTaxes\Config::get_php_version
+	 */
+	public function testEnvironmentCompatibleFalse() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Config' )->makePartial();
+		$mock->shouldReceive( 'get_php_version' )->andReturn( '100.0' );
+		$this->assertFalse( $mock->is_environment_compatible() );
 	}
 
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -6,7 +6,6 @@
  */
 
 use Niteo\WooCart\EUVatTaxes\UserView;
-use Niteo\WooCart\EUVatTaxes\Vies;
 use PHPUnit\Framework\TestCase;
 
 class UserViewTest extends TestCase {
@@ -657,5 +656,16 @@ class UserViewTest extends TestCase {
 		$this->assertInstanceOf( '\Niteo\WooCart\EUVatTaxes\Vies', $user->vies() );
 	}
 
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::get_digital_tax_rate_for_user
+	 */
+	public function testGetDigitalTaxRate() {
+		$user = new UserView();
+		$wc   = \Mockery::mock( 'alias:\WC_Tax' );
+		$wc->shouldReceive( 'get_rates' )->andReturn( array() );
+
+		$this->assertEquals( array(), $user->get_digital_tax_rate_for_user() );
+	}
 
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -44,30 +44,28 @@ class UserViewTest extends TestCase {
 		$user = new UserView();
 
 		\WP_Mock::userFunction(
-			'admin_url',
+			'sanitize_text_field',
 			array(
+				'times'  => 7,
 				'return' => true,
 			)
 		);
 		\WP_Mock::userFunction(
-			'wp_create_nonce',
+			'get_option',
 			array(
+				'times'  => 7,
 				'return' => true,
 			)
 		);
-		\WP_Mock::userFunction(
-			'wp_localize_script',
-			array(
-				'return' => true,
-			)
-		);
-
-		\WP_Mock::expectActionAdded( 'wp_enqueue_scripts', array( $user, 'scripts' ) );
-		\WP_Mock::expectActionAdded( 'woocommerce_checkout_update_order_review', array( $user, 'calculate_tax' ) );
-		\WP_Mock::expectActionAdded( 'woocommerce_after_checkout_validation', array( $user, 'checkout_validation' ), PHP_INT_MAX, 2 );
-		\WP_Mock::expectActionAdded( 'woocommerce_checkout_update_order_meta', array( $user, 'update_order_meta' ), 10, 1 );
 
 		\WP_Mock::expectFilterAdded( 'woocommerce_billing_fields', array( $user, 'checkout_fields' ) );
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_class', array( $user, 'digital_goods' ), PHP_INT_MAX, 2 );
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_status', array( $user, 'digital_goods_verify' ), PHP_INT_MAX, 2 );
+
+		\WP_Mock::expectActionAdded( 'wp_enqueue_scripts', array( $user, 'scripts' ) );
+		\WP_Mock::expectActionAdded( 'woocommerce_checkout_update_order_review', array( $user, 'b2b_taxes' ), PHP_INT_MAX );
+		\WP_Mock::expectActionAdded( 'woocommerce_after_checkout_validation', array( $user, 'checkout_validation' ), PHP_INT_MAX, 2 );
+		\WP_Mock::expectActionAdded( 'woocommerce_checkout_update_order_meta', array( $user, 'update_order_meta' ) );
 
 		$user->init();
 		\WP_Mock::assertHooksAdded();
@@ -92,6 +90,24 @@ class UserViewTest extends TestCase {
 				'return' => true,
 			)
 		);
+		\WP_Mock::userFunction(
+			'admin_url',
+			array(
+				'return' => true,
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_create_nonce',
+			array(
+				'return' => true,
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_localize_script',
+			array(
+				'return' => true,
+			)
+		);
 
 		$user->scripts();
 	}
@@ -100,9 +116,15 @@ class UserViewTest extends TestCase {
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_fields
 	 */
-	public function testCheckoutFields() {
+	public function testCheckoutFieldsB2bNone() {
 		$user = new UserView();
 
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'return' => 'none',
+			)
+		);
 		\WP_Mock::userFunction(
 			'get_option',
 			array(
@@ -110,227 +132,530 @@ class UserViewTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals( array(), $user->checkout_fields( array() ) );
+		$this->assertEquals(
+			array(),
+			$user->checkout_fields( array() )
+		);
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_fields
 	 */
-	public function testCheckoutFieldsNotEmpty() {
+	public function testCheckoutFieldsB2bNotNone() {
 		$user = new UserView();
 
 		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'return' => 'not_none',
+			)
+		);
+		\WP_Mock::userFunction(
 			'get_option',
 			array(
-				'return' => 'notnone',
+				'return' => 'not_none',
 			)
 		);
 
-		$this->assertNotEquals( array(), $user->checkout_fields( array() ) );
+		$this->assertEquals(
+			array(
+				'business_check'  => array(
+					'label'    => 'Are you making this purchase as a Business entity?',
+					'type'     => 'checkbox',
+					'required' => false,
+					'class'    => array( 'wc-euvat-business-check', 'update_totals_on_change' ),
+					'clear'    => true,
+					'priority' => 5,
+				),
+				'business_tax_id' => array(
+					'label'    => 'Business Tax ID',
+					'type'     => 'text',
+					'required' => false,
+					'class'    => array( 'form-row-wide', 'wc-euvat-hidden', 'update_totals_on_change' ),
+					'priority' => 6,
+				),
+			),
+			$user->checkout_fields( array() )
+		);
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::return_tax
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods
 	 */
-	public function testReturnTax() {
-		$user = new UserView();
+	public function testDigitalGoodsNoTax() {
+		$user                     = new UserView();
+		$user->enable_digital_tax = 'no';
 
-		$this->assertEmpty( $user->return_tax( '', '', '', false, false ) );
+		$this->assertEquals(
+			'tax-class',
+			$user->digital_goods( 'tax-class', (object) array() )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods
+	 */
+	public function testDigitalGoodsWithTax() {
+		$user                     = new UserView();
+		$user->enable_digital_tax = 'yes';
+
+		$product = new class() {
+			function get_virtual() {
+				return false;
+			}
+
+			function get_downloadable() {
+				return false;
+			}
+		};
+
+		$this->assertEquals(
+			'tax-class',
+			$user->digital_goods( 'tax-class', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods
+	 */
+	public function testDigitalGoodsWithDigitalTax() {
+		$user                     = new UserView();
+		$user->enable_digital_tax = 'yes';
+
+		$product = new class() {
+			function get_virtual() {
+				return true;
+			}
+
+			function get_downloadable() {
+				return true;
+			}
+		};
+
+		$this->assertEquals(
+			'digital-goods',
+			$user->digital_goods( 'tax-class', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods_verify
+	 */
+	public function testDigitalGoodsVerifyNoTax() {
+		$user                     = new UserView();
+		$user->enable_digital_tax = 'no';
+
+		$this->assertEquals(
+			'tax-status',
+			$user->digital_goods_verify( 'tax-status', (object) array() )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods_verify
+	 */
+	public function testDigitalGoodsVerifyWithTax() {
+		$user                     = new UserView();
+		$user->enable_digital_tax = 'yes';
+
+		$product = new class() {
+			function get_virtual() {
+				return false;
+			}
+
+			function get_downloadable() {
+				return false;
+			}
+		};
+
+		$this->assertEquals(
+			'tax-status',
+			$user->digital_goods_verify( 'tax-status', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods_verify
+	 */
+	public function testDigitalGoodsVerifyWithTaxNoRates() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )
+						->shouldAllowMockingProtectedMethods()
+						->makePartial();
+		$mock->shouldReceive( 'get_digital_tax_rate_for_user' )->andReturn( array() );
+		$mock->enable_digital_tax = 'yes';
+
+		$product = new class() {
+			function get_virtual() {
+				return true;
+			}
+
+			function get_downloadable() {
+				return true;
+			}
+		};
+
+		$this->assertEquals(
+			'none',
+			$mock->digital_goods_verify( 'tax-status', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::digital_goods_verify
+	 */
+	public function testDigitalGoodsVerifyWithTaxWithRates() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )
+						->shouldAllowMockingProtectedMethods()
+						->makePartial();
+		$mock->shouldReceive( 'get_digital_tax_rate_for_user' )->andReturn( array( 'standard_rate' => '10.00' ) );
+		$mock->enable_digital_tax = 'yes';
+
+		$product = new class() {
+			function get_virtual() {
+				return true;
+			}
+
+			function get_downloadable() {
+				return true;
+			}
+		};
+
+		$this->assertEquals(
+			'tax-status',
+			$mock->digital_goods_verify( 'tax-status', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::b2b_taxes
+	 */
+	public function testB2bTaxesNoStatus() {
+		$user                   = new UserView();
+		$user->b2b_sales_status = 'none';
+
+		$this->assertEmpty( $user->b2b_taxes( 'checkout_data' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::b2b_taxes
+	 */
+	public function testB2bTaxesWithStatusNoBusinessCheck() {
+		$user                   = new UserView();
+		$user->b2b_sales_status = 'not_none';
+
+		$this->assertEmpty( $user->b2b_taxes( 'checkout_data=none' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::b2b_taxes
+	 */
+	public function testB2bTaxesWithStatusEmptyBusinessCheck() {
+		$user                   = new UserView();
+		$user->b2b_sales_status = 'not_none';
+
+		$this->assertEmpty( $user->b2b_taxes( 'business_check=' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::b2b_taxes
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 */
+	public function testB2bTaxesWithStatusWithBusinessCheck() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
+		$mock->shouldReceive( 'validate_b2b_sales_home_country' )->andReturn();
+		$mock->b2b_sales_status = 'not_none';
+		$mock->store_country    = 'france';
+
+		$this->assertEmpty( $mock->b2b_taxes( 'business_check=yes&billing_country=france' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::b2b_taxes
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_outside_home_country
+	 */
+	public function testB2bTaxesWithStatusWithBusinessCheckOtherCountry() {
+		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
+		$mock->shouldReceive( 'validate_b2b_sales_outside_home_country' )->andReturn();
+		$mock->b2b_sales_status = 'not_none';
+		$mock->store_country    = 'slovenia';
+
+		$this->assertEmpty( $mock->b2b_taxes( 'business_check=yes&billing_country=france' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 */
+	public function testValidateB2bSales() {
+		$user                              = new UserView();
+		$user->b2b_charge_tax_home_country = 'no';
+
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_class', array( $user, 'zero_rate_tax' ), PHP_INT_MAX, 2 );
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_status', array( $user, 'zero_rate_tax_verify' ), PHP_INT_MAX, 2 );
+
+		$user->validate_b2b_sales_home_country( array() );
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 */
+	public function testValidateB2bSalesNoVies() {
+		$user                              = new UserView();
+		$user->b2b_charge_tax_home_country = 'yes';
+		$user->b2b_no_tax_valid_vies       = 'no';
+
+		$this->assertEmpty( $user->validate_b2b_sales_home_country( array() ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 */
+	public function testValidateB2bSalesEmptyTaxId() {
+		$user                              = new UserView();
+		$user->b2b_charge_tax_home_country = 'yes';
+		$user->b2b_no_tax_valid_vies       = 'yes';
+
+		$this->assertEmpty( $user->validate_b2b_sales_home_country( array() ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValid
+	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValidCountryCode
+	 */
+	public function testValidateB2bSalesValidEntry() {
+		$mock                              = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
+		$mock->b2b_charge_tax_home_country = 'yes';
+		$mock->b2b_no_tax_valid_vies       = 'yes';
+
+		$vies = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Vies' );
+		$vies->shouldReceive( 'isValid' )->andReturn( true );
+		$mock->shouldReceive( 'vies' )->andReturn( $vies );
+
+		$mock->validate_b2b_sales_home_country( array( 'business_tax_id' => 'not_empty' ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_home_country
+	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValid
+	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValidCountryCode
+	 */
+	public function testValidateB2bSalesInvalidEntry() {
+		$mock                              = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
+		$mock->b2b_charge_tax_home_country = 'yes';
+		$mock->b2b_no_tax_valid_vies       = 'yes';
+
+		$vies = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Vies' );
+		$vies->shouldReceive( 'isValid' )->andReturn( false );
+		$mock->shouldReceive( 'vies' )->andReturn( $vies );
+
+		$this->assertEmpty( $mock->validate_b2b_sales_home_country( array( 'business_tax_id' => 'not_empty' ) ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_outside_home_country
+	 */
+	public function testValidateB2bSalesOutsideHomeCountryNoTax() {
+		$user                             = new UserView();
+		$user->b2b_no_tax_outside_country = 'no';
+
+		$this->assertEmpty( $user->validate_b2b_sales_outside_home_country() );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::validate_b2b_sales_outside_home_country
+	 */
+	public function testValidateB2bSalesOutsideHomeCountryWithTax() {
+		$user                             = new UserView();
+		$user->b2b_no_tax_outside_country = 'yes';
+
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_class', array( $user, 'zero_rate_tax' ), PHP_INT_MAX, 2 );
+		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_tax_status', array( $user, 'zero_rate_tax_verify' ), PHP_INT_MAX, 2 );
+
+		$user->validate_b2b_sales_outside_home_country();
+		\WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::zero_rate_tax
+	 */
+	public function testZeroTaxRate() {
+		$user = new UserView();
+		$this->assertEquals(
+			'Zero rate',
+			$user->zero_rate_tax( 'tax-class', (object) array() )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::zero_rate_tax_verify
+	 */
+	public function testZeroTaxRateVerifyZeroRate() {
+		$user    = new UserView();
+		$product = new class() {
+			function get_tax_class() {
+				return 'Zero rate';
+			}
+		};
+
+		$this->assertEquals(
+			'none',
+			$user->zero_rate_tax_verify( 'tax-status', $product )
+		);
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::zero_rate_tax_verify
+	 */
+	public function testZeroTaxRateVerifyNotZeroRate() {
+		$user    = new UserView();
+		$product = new class() {
+			function get_tax_class() {
+				return 'Not Zero';
+			}
+		};
+
+		$this->assertEquals(
+			'tax-status',
+			$user->zero_rate_tax_verify( 'tax-status', $product )
+		);
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_validation
 	 */
-	public function testCheckoutValidation() {
-		$user = new UserView();
+	public function testCheckoutValidationNoTaxRequired() {
+		$user                      = new UserView();
+		$user->b2b_tax_id_required = 'no';
+		$errors                    = \Mockery::mock( '\WP_Error' );
 
-		$_POST['business_check'] = 'yes';
+		$this->assertEmpty( $user->checkout_validation( array(), $errors ) );
+	}
 
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'return' => 'yes',
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_validation
+	 */
+	public function testCheckoutValidationNoBusinessCheck() {
+		$user                      = new UserView();
+		$user->b2b_tax_id_required = 'yes';
+		$errors                    = \Mockery::mock( '\WP_Error' );
+
+		$this->assertEmpty( $user->checkout_validation( array(), $errors ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_validation
+	 */
+	public function testCheckoutValidationTaxIdNotEmpty() {
+		$user                      = new UserView();
+		$user->b2b_tax_id_required = 'yes';
+
+		$errors = \Mockery::mock( '\WP_Error' );
+		$this->assertEmpty(
+			$user->checkout_validation(
+				array(
+					'business_check'  => 'yes',
+					'business_tax_id' => 'not_empty',
+				),
+				$errors
 			)
 		);
+	}
 
-		$mock = \Mockery::mock( '\WP_Error' );
-		$mock->shouldReceive( 'add' )
-			 ->with( 'billing', '<strong>Business Tax ID</strong> is a required field.' )
-			 ->andReturns( true );
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::checkout_validation
+	 */
+	public function testCheckoutValidationTaxIdEmpty() {
+		$user                      = new UserView();
+		$user->b2b_tax_id_required = 'yes';
 
-		$user->checkout_validation( '', $mock );
+		$errors = \Mockery::mock( '\WP_Error' );
+		$errors->shouldReceive( 'add' )->andReturn();
+
+		$this->assertEmpty(
+			$user->checkout_validation(
+				array(
+					'business_check'  => 'yes',
+					'business_tax_id' => '',
+				),
+				$errors
+			)
+		);
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::update_order_meta
 	 */
-	public function testUpdateOrderMeta() {
+	public function testUpdateOrderMetaNoBusinessCheck() {
+		$user = new UserView();
+		$this->assertEmpty( $user->update_order_meta( 20 ) );
+	}
+
+	/**
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::update_order_meta
+	 */
+	public function testUpdateOrderMetaWithBusinessCheck() {
 		$user = new UserView();
 
-		$_POST['business_check']  = 'NOT_EMPTY';
-		$_POST['business_tax_id'] = 'NOT_EMPTY';
+		$_POST['business_check']  = 'yes';
+		$_POST['business_tax_id'] = 'TAX_ID';
 
-		\WP_Mock::userFunction(
-			'update_post_meta',
-			array(
-				'return' => true,
-			)
-		);
 		\WP_Mock::userFunction(
 			'sanitize_text_field',
 			array(
-				'return' => true,
+				'times'  => 2,
+				'return' => 'not_empty',
 			)
 		);
-
-		$user->update_order_meta( '1000' );
-	}
-
-	/**
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::calculate_tax
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::set_vat_exempt
-	 */
-	public function testCalculateTaxb2bNone() {
-		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
-		$mock->shouldReceive( 'set_vat_exempt' )->andReturn( true );
-
 		\WP_Mock::userFunction(
-			'get_option',
+			'update_post_meta',
 			array(
-				'args'   => array(
-					'wc_b2b_sales',
-				),
-				'return' => 'none',
+				'times'  => 2,
+				'return' => 'true',
 			)
 		);
 
-		$mock->calculate_tax( 'billing_country=India&business_check=1' );
+		$user->update_order_meta( 20 );
 	}
 
 	/**
 	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::calculate_tax
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::set_vat_exempt
+	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::vies
 	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValid
-	 * @covers \Niteo\WooCart\EUVatTaxes\Vies::isValidCountryCode
 	 */
-	public function testCalculateTaxb2bNotNone() {
-		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
-		$mock->shouldReceive( 'set_vat_exempt' )->andReturn( true );
-
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_b2b_sales',
-				),
-				'return' => 'not_none',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_home_country',
-				),
-				'return' => 'no',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_charge_vat',
-				),
-				'return' => 'yes',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_eu_with_vatid',
-				),
-				'return' => 'yes',
-			)
-		);
-		\WP_Mock::userFunction(
-			'wc_get_base_location',
-			array(
-				'return' => array(
-					'country' => 'India',
-				),
-			)
-		);
-
-		$vies = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\Vies' );
-		$vies->shouldReceive( 'isValid' )
-				->andReturn( true );
-
-		$mock->calculate_tax( 'billing_country=India&business_check=1&business_tax_id=VAT_ID' );
+	public function testVies() {
+		$user = new UserView();
+		$this->assertInstanceOf( '\Niteo\WooCart\EUVatTaxes\Vies', $user->vies() );
 	}
 
-	/**
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::__construct
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::calculate_tax
-	 * @covers \Niteo\WooCart\EUVatTaxes\UserView::set_vat_exempt
-	 */
-	public function testCalculateTaxb2bNotNoneDiffCountry() {
-		$mock = \Mockery::mock( '\Niteo\WooCart\EUVatTaxes\UserView' )->makePartial();
-		$mock->shouldReceive( 'set_vat_exempt' )->andReturn( true );
-
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_b2b_sales',
-				),
-				'return' => 'not_none',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_home_country',
-				),
-				'return' => 'no',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_charge_vat',
-				),
-				'return' => 'yes',
-			)
-		);
-		\WP_Mock::userFunction(
-			'get_option',
-			array(
-				'args'   => array(
-					'wc_tax_eu_with_vatid',
-				),
-				'return' => 'yes',
-			)
-		);
-		\WP_Mock::userFunction(
-			'wc_get_base_location',
-			array(
-				'return' => array(
-					'country' => 'India',
-				),
-			)
-		);
-
-		$mock->calculate_tax( 'billing_country=Spain&business_check=1' );
-	}
 
 }


### PR DESCRIPTION
This PR is to polish the new release of the plugin and to fix any bugs found during testing. Also, this adds couple of checks and notifications for the plugin so as to ensure that the plugin is loaded only in the right environment. It checks for the minimum required versions for PHP, WP, and WooCommerce.

Minimum WP version - `4.8.12`
Minimum WC version - `4.2.0`

## Testing

### Scenario 1
Testing for Digital Goods

- After importing taxes in WC Settings, all digital products must be assigned the `digital-goods` for them to charge the desired tax.
- If the option for `Digital Goods` is enabled, then the tax charge will be shown during checkout.
- If the option is not enabled, then standard tax rates will be applied.

<img width="445" alt="Screenshot 2020-06-30 at 5 44 46 AM" src="https://user-images.githubusercontent.com/266324/86068379-d8983000-ba94-11ea-9960-f7a34a2f5c3b.png">

### Scenario 2
Testing for Distance Selling

- All countries need to be selected from the `multi-select` countries dropdown for whom tax rates are required. If the country selected falls outside the EU region, then it will simply be ignored.
- Similar to digital goods, all products must be assigned the `distance-selling` tax class or if not assigned, it will be assigned during checkout by the plugin.
- If the customer's country falls within the list of countries selected for `distance-selling`, then the applicable tax shall be applied to products.
- While working on this feature, it looked to me like a duplicate of `standard-taxes`. For example - customers will still be applied taxes in their local country if tax rates for the given country exists in the system. So, we can limit the number of selling countries via WC settings and import standard taxes and this feature should work similar to what we are trying to achieve via `distance-selling`.

### Scenario 3
B2B Taxes for Non-European stores

- Starting with the option for `Non-EU store`. I believe this option should be revisited because the plugin is aimed towards `EU taxes` only.
- The only purpose it can solve is that Non-EU stores can have B2B sales. The information for taxes used will only be the one which the store origin country has along with EU taxes if they intend on selling in the EU region.
- This feature has 3 sub-scenarios:

    1. Tax ID field required for B2B - With this option enabled, if the checkbox for B2B sale is checked, the plugin will not try to validate the Tax ID. This is for two reasons. Firstly, because the country is non-EU and tax validation is only for EU tax ID's. Secondly, we don't provide the option for validation in the settings for non-EU stores even if the buyer is from an EU country.
    2. B2B sales in the home country - If option to charge tax is not enabled, then all taxes will be removed for the user buying from the same country as store's base country.
    3. B2B sales outside the country - If the option to not charge tax is enabled, then again, all taxes will be removed for the user buying from the any other country and not the store's base country.

### Scenario 4
B2B Taxes for European stores

- Three scenarios for European stores are similar to that of Non-European stores and they function exactly the same.
- B2B sales in the EU when VIES/VAT ID is provided - With this option enabled, the plugin will try to validate the Tax ID via the API. If somehow, the API is not present, the sale won't happen unless the customer makes a regular purchase.

On the admin side, tax ID can be re-validated on the order page itself. The screenshot below shows how it looks:

<img width="446" alt="Screenshot 2020-06-30 at 6 17 14 AM" src="https://user-images.githubusercontent.com/266324/86070106-6ece5500-ba99-11ea-8d6c-751d68a100fc.png">

For Reports, we can see the B2B transactions in a table format as shown under:

<img width="1069" alt="Screenshot 2020-06-30 at 6 18 41 AM" src="https://user-images.githubusercontent.com/266324/86070188-a50bd480-ba99-11ea-9eec-b789b80928b7.png">

and taxes collected by country report as:

<img width="1066" alt="Screenshot 2020-06-30 at 6 20 44 AM" src="https://user-images.githubusercontent.com/266324/86070271-e00e0800-ba99-11ea-9ac1-ac9d37b9ad4e.png">

Few improvements (which should be done to polish the plugin a bit)
- Revisit the `distance-selling` feature to determine if we can scrape it or if it needs to stay.
- Make tax validation rollback to regular purchase if the API is not available or unable to verify for whatever reason.
- Show notifications while importing taxes so that the user knows that it's under process.
- Instead of letting user define countries for distance selling, grab the countries where the store is selling as it makes more sense to use this setting.